### PR TITLE
QnA 메인 페이지 프로토타입 구현

### DIFF
--- a/frontend/src/components/qna/QnaPostList.tsx
+++ b/frontend/src/components/qna/QnaPostList.tsx
@@ -3,12 +3,13 @@ import { css, jsx } from "@emotion/core";
 
 export interface QnaPostListProps {}
 
-export const QnaPostList: React.FC = ({ children }) => (
+export const QnaPostList: React.FC = ({ children, ...props }) => (
   <div
     css={css`
       display: flex;
       flex-direction: column;
     `}
+    {...props}
   >
     {children}
   </div>

--- a/frontend/src/components/qna/QnaSideBar.tsx
+++ b/frontend/src/components/qna/QnaSideBar.tsx
@@ -1,0 +1,58 @@
+/** @jsx jsx */
+import { css, jsx } from "@emotion/core";
+import styled from "@emotion/styled";
+
+export interface QnaSideBarProps {}
+
+const Link = styled.div`
+  font-size: 14px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 20px;
+  letter-spacing: -0.02em;
+  text-align: left;
+
+  padding-bottom: 12px;
+`;
+
+export const QnaSideBar: React.FC = (props) => (
+  <div
+    css={css`
+      max-width: 200px;
+    `}
+    {...props}
+  >
+    <div>
+      <Link>새로운 질문</Link>
+      <Link>답변을 기다리는 질문</Link>
+      <Link>나의 질문</Link>
+    </div>
+    <div
+      css={css`
+        padding-top: 48px;
+      `}
+    >
+      <div
+        css={css`
+          font-size: 12px;
+          font-style: normal;
+          font-weight: 400;
+          line-height: 17px;
+          letter-spacing: -0.02em;
+          text-align: left;
+
+          padding-bottom: 15px;
+          color: #6f6f6f;
+        `}
+      >
+        인기 태그
+      </div>
+      <Link>안드로이드</Link>
+      <Link>Python</Link>
+      <Link>Javascript</Link>
+      <Link>React.js</Link>
+      <Link>ReactNative</Link>
+      <Link>Kotlin</Link>
+    </div>
+  </div>
+);

--- a/frontend/src/containers/qna/QnaHomeContainer.tsx
+++ b/frontend/src/containers/qna/QnaHomeContainer.tsx
@@ -1,6 +1,24 @@
 /** @jsx jsx */
 import { css, jsx } from "@emotion/core";
 import { Button } from "../../components/common/Button";
+import { QnaPostItem } from "../../components/qna/QnaPostItem";
+import { QnaPostList } from "../../components/qna/QnaPostList";
+import { QnaSideBar } from "../../components/qna/QnaSideBar";
+import { QnaPost } from "../../modules/qna";
+
+const generatePosts = (num: number): QnaPost[] =>
+  new Array(num).fill(null).map((_, idx) => ({
+    id: idx + 1,
+    user_id: "seowook1963",
+    title: "안드로이드 블루투스 연결 질문",
+    body:
+      "앞이 날카로우나 방황하였으며, 남는 황금시대의 커다란 그리하였는가?\n피에 불어 용감하고 말이다. 청춘에서만 듣기만 앞이 많이 부패뿐이다. 노년에게서 커다란 것이다.보라, 군영과 영락과 하여도...앞이 날카로우나 방황하였으며, 남는 황금시대의 커다란 그리하였는가? 피에 불어 용감하고 말이다. 청춘에서만 듣기만 앞이 많이 부패뿐이다. 노년에게서 커다란 것이다.보라, 군영과 영락과 하여도...",
+    tag: "안드로이드",
+    view: 321,
+    recommend: 14,
+    created_at: new Date(),
+    updated_at: new Date(),
+  }));
 
 export const QnaHomeContainer: React.FC = (props) => {
   return (
@@ -12,47 +30,96 @@ export const QnaHomeContainer: React.FC = (props) => {
       `}
       {...props}
     >
-      <div
-        css={css`
-          font-size: 36px;
-          font-style: normal;
-          font-weight: 700;
-          line-height: 48px;
-          letter-spacing: -0.02em;
-          text-align: left;
+      <div>
+        <div
+          css={css`
+            font-size: 36px;
+            font-style: normal;
+            font-weight: 700;
+            line-height: 48px;
+            letter-spacing: -0.02em;
+            text-align: left;
 
-          padding-bottom: 24px;
-        `}
-      >
-        혼자 고민하지 말고,
-        <br />
-        전우에게 물어보세요
+            padding-bottom: 24px;
+          `}
+        >
+          혼자 고민하지 말고,
+          <br />
+          전우에게 물어보세요
+        </div>
+        <div
+          css={css`
+            font-size: 18px;
+            font-style: normal;
+            font-weight: 400;
+            line-height: 26px;
+            letter-spacing: -0.02em;
+            text-align: left;
+
+            padding-bottom: 40px;
+          `}
+        >
+          해결되지 않는 문제가 있나요?
+          <br />
+          코드스퀘어의 전우들에게 물어보세요.
+        </div>
+        <Button
+          css={css`
+            height: 42px;
+            width: 116px;
+            border-radius: 6px;
+          `}
+        >
+          질문하기
+        </Button>
       </div>
       <div
         css={css`
-          font-size: 18px;
-          font-style: normal;
-          font-weight: 400;
-          line-height: 26px;
-          letter-spacing: -0.02em;
-          text-align: left;
+          display: flex;
+          padding-top: 120px;
+        `}
+      >
+        <QnaSideBar
+          css={css`
+            width: 200px;
+          `}
+        />
+        <div
+          css={css`
+            padding-left: 16px;
+            flex: 1 1 0%;
+          `}
+        >
+          <input
+            css={css`
+              width: 100%;
+              height: 38px;
+              background: #ffffff;
+              border: 1px solid #b4b4b4;
+              box-sizing: border-box;
+              border-radius: 6px;
+              padding: 16px 9px;
 
-          padding-bottom: 40px;
-        `}
-      >
-        해결되지 않는 문제가 있나요?
-        <br />
-        코드스퀘어의 전우들에게 물어보세요.
+              font-size: 14px;
+              font-style: normal;
+              font-weight: 400;
+              line-height: 20px;
+              letter-spacing: -0.02em;
+              text-align: left;
+            `}
+            placeholder="질문 검색"
+          />
+          <QnaPostList
+            css={css`
+              padding-top: 38px;
+            `}
+          >
+            {generatePosts(3).map((post) => (
+              <QnaPostItem key={post.id} post={post} />
+            ))}
+          </QnaPostList>
+        </div>
       </div>
-      <Button
-        css={css`
-          height: 42px;
-          width: 116px;
-          border-radius: 6px;
-        `}
-      >
-        질문하기
-      </Button>
     </div>
   );
 };

--- a/frontend/src/stories/qna/QnaSideBar.stories.tsx
+++ b/frontend/src/stories/qna/QnaSideBar.stories.tsx
@@ -1,0 +1,16 @@
+/** @jsx jsx */
+import { jsx } from "@emotion/core";
+// also exported from '@storybook/react' if you can deal with breaking changes in 6.1
+import { Story, Meta } from "@storybook/react/types-6-0";
+
+import { QnaSideBar, QnaSideBarProps } from "../../components/qna/QnaSideBar";
+
+export default {
+  title: "qna/QnaSideBar",
+  component: QnaSideBar,
+} as Meta;
+
+const Template: Story<QnaSideBarProps> = (args) => <QnaSideBar {...args} />;
+
+export const Default = Template.bind({});
+Default.args = {};


### PR DESCRIPTION
![145](https://user-images.githubusercontent.com/17797795/95657496-b6ac5000-0b4f-11eb-9b4f-22f681ebc1ef.png)

#7 

### 주요 변경사항
 - QnaSideBar 컴포넌트 추가 (https://github.com/osamhack2020/WEB_CodeSquare_AmongUs/commit/70c9a2142052a1ca3cdf303e925e02f618792ec4)

### 기타 변경사항
 - QnaPostList 컴포넌트가 children을 제외한 다른 props를 받을 수 있도록 수정 (https://github.com/osamhack2020/WEB_CodeSquare_AmongUs/commit/70c9a2142052a1ca3cdf303e925e02f618792ec4)