### PR TITLE
QnA 프로토타입 작업 1

### DIFF
--- a/frontend/mock-server.js
+++ b/frontend/mock-server.js
@@ -5,6 +5,21 @@ const logger = require("koa-logger");
 const app = new Koa();
 const router = new Router();
 
+let POST_ID = 1;
+const generatePosts = (num) =>
+  new Array(num).fill(null).map((_, idx) => ({
+    id: POST_ID++,
+    user_id: "seowook1963",
+    title: "안드로이드 블루투스 연결 질문",
+    body:
+      "앞이 날카로우나 방황하였으며, 남는 황금시대의 커다란 그리하였는가?\n피에 불어 용감하고 말이다. 청춘에서만 듣기만 앞이 많이 부패뿐이다. 노년에게서 커다란 것이다.보라, 군영과 영락과 하여도...앞이 날카로우나 방황하였으며, 남는 황금시대의 커다란 그리하였는가? 피에 불어 용감하고 말이다. 청춘에서만 듣기만 앞이 많이 부패뿐이다. 노년에게서 커다란 것이다.보라, 군영과 영락과 하여도...",
+    tag: "안드로이드",
+    view: 321,
+    recommend: 14,
+    created_at: new Date(),
+    updated_at: new Date(),
+  }));
+
 router
   .post("/user/signup", (ctx) => {
     ctx.body = "";
@@ -34,6 +49,13 @@ router
         data: null,
       };
     }
+  })
+  .get("/board/:id", (ctx) => {
+    ctx.body = {
+      response: "success",
+      message: "조회성공",
+      data: { totalPage: 3, boards: generatePosts(10) },
+    };
   });
 
 app

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,7 @@ import { RegisterContainer } from "./containers/auth/RegisterContainer";
 import { HomeContainer } from "./containers/HomeContainer";
 import { ProfileContainer } from "./containers/profile/ProfileContainer";
 import { QnaHomeContainer } from "./containers/qna/QnaHomeContainer";
+import { QnaPostContainer } from "./containers/qna/QnaPostContainer";
 import { VmHomeContainer } from "./containers/vm/VmHomeContainer";
 import { RootState } from "./modules";
 
@@ -33,13 +34,11 @@ const App: React.FC = () => {
         <Route path="/vm">
           <VmHomeContainer />
         </Route>
-        <Route path="/qna">
-          <QnaHomeContainer
-            css={css`
-              margin: 0 auto;
-              padding-top: 83px;
-            `}
-          />
+        <Route path="/qna" exact>
+          <QnaHomeContainer />
+        </Route>
+        <Route path="/qna/:id">
+          <QnaPostContainer />
         </Route>
         <Route path="/login">
           <LoginContainer

--- a/frontend/src/components/base/Header.tsx
+++ b/frontend/src/components/base/Header.tsx
@@ -75,9 +75,11 @@ export const Header: React.FC = ({ ...props }) => {
             `}
           >
             <div>
-              <WrapperLink to="vm">개발하기</WrapperLink>
+              <WrapperLink to="/vm">개발하기</WrapperLink>
             </div>
-            <div>Q&A</div>
+            <div>
+              <WrapperLink to="/qna">Q&A</WrapperLink>
+            </div>
             <div>매거진</div>
             <div>GitLab</div>
           </div>

--- a/frontend/src/components/common/OutlineButton.tsx
+++ b/frontend/src/components/common/OutlineButton.tsx
@@ -1,0 +1,21 @@
+/** @jsx jsx */
+import { css, jsx } from "@emotion/core";
+import { Button, ButtonProps } from "./Button";
+
+export type OutlineButtonProps = ButtonProps & {
+  color?: string;
+};
+
+export const OutlineButton: React.FC<OutlineButtonProps> = ({
+  color,
+  ...props
+}) => (
+  <Button
+    css={css`
+      background: none;
+      color: ${color ? color : "#627bff"};
+      border: 1px solid ${color ? color : "#627bff"};
+    `}
+    {...props}
+  ></Button>
+);

--- a/frontend/src/components/common/Sticky.tsx
+++ b/frontend/src/components/common/Sticky.tsx
@@ -1,0 +1,56 @@
+/** @jsx jsx */
+import { css, jsx } from "@emotion/core";
+import React, { useState, useCallback, useRef, useEffect } from "react";
+import { getScrollTop } from "../../lib/utils";
+
+export interface StickyProps {
+  top: number;
+}
+
+export const Sticky: React.FC<StickyProps> = ({ top, children, ...props }) => {
+  const [y, setY] = useState(0);
+  const element = useRef<HTMLDivElement | null>(null);
+  const [fixed, setFixed] = useState(false);
+
+  const setup = useCallback(() => {
+    if (!element.current) return;
+    const pos = element.current.getBoundingClientRect();
+    setY(pos.top + getScrollTop());
+  }, []);
+
+  const onScroll = useCallback(() => {
+    const scrollTop = getScrollTop();
+    const nextFixed = scrollTop + 112 > y;
+    if (fixed !== nextFixed) {
+      setFixed(nextFixed);
+    }
+  }, [fixed, y]);
+
+  useEffect(() => {
+    setup();
+  }, [setup]);
+
+  // register scroll event
+  useEffect(() => {
+    window.addEventListener("scroll", onScroll);
+    return () => {
+      window.removeEventListener("scroll", onScroll);
+    };
+  }, [onScroll]);
+
+  return (
+    <div
+      ref={element}
+      css={css`
+        ${fixed &&
+        css`
+          position: fixed;
+          top: ${top}px;
+        `}
+      `}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+};

--- a/frontend/src/components/common/VerticalDivider.tsx
+++ b/frontend/src/components/common/VerticalDivider.tsx
@@ -1,0 +1,27 @@
+/** @jsx jsx */
+import { css, jsx } from "@emotion/core";
+
+interface VerticalDividerProps {
+  height: number;
+}
+
+export const VerticalDivider: React.FC<VerticalDividerProps> = ({
+  height,
+  ...props
+}) => (
+  <svg
+    css={css`
+      width: 1px;
+      height: ${height}px;
+      fill: black;
+
+      rect {
+        width: 1px;
+        height: ${height}px;
+      }
+    `}
+    {...props}
+  >
+    <rect />
+  </svg>
+);

--- a/frontend/src/components/qna/QnaCommentItem.tsx
+++ b/frontend/src/components/qna/QnaCommentItem.tsx
@@ -1,0 +1,93 @@
+/** @jsx jsx */
+import { css, jsx } from "@emotion/core";
+import { Comment } from "../../modules/qna";
+
+export interface QnaCommentItemProps {
+  comment: Comment;
+}
+
+export const QnaCommentItem: React.FC<QnaCommentItemProps> = ({
+  comment,
+  ...props
+}) => (
+  <div
+    css={css`
+      display: flex;
+      flex-direction: column;
+      padding: 10px 0px;
+    `}
+    {...props}
+  >
+    <div
+      css={css`
+        display: flex;
+        justify-content: space-between;
+        padding-bottom: 4px;
+      `}
+    >
+      <div
+        css={css`
+          display: flex;
+        `}
+      >
+        <div
+          css={css`
+            font-size: 13px;
+            font-style: normal;
+            font-weight: 700;
+            line-height: 19px;
+            letter-spacing: -0.02em;
+            text-align: left;
+            padding-right: 6px;
+          `}
+        >
+          {comment.user.username}
+        </div>
+        {comment.isAuthor && (
+          <div
+            css={css`
+              align-self: center;
+              padding: 1px 6px;
+              border: 1px solid #627bff;
+              box-sizing: border-box;
+              border-radius: 10px;
+
+              font-style: normal;
+              font-weight: normal;
+              font-size: 9px;
+              line-height: 13px;
+              letter-spacing: -0.02em;
+
+              color: #627bff;
+            `}
+          >
+            질문자
+          </div>
+        )}
+      </div>
+      <div
+        css={css`
+          font-size: 12px;
+          font-style: normal;
+          font-weight: 400;
+          line-height: 17px;
+          letter-spacing: -0.02em;
+          text-align: left;
+        `}
+      >
+        {comment.created_at}
+      </div>
+    </div>
+    <div
+      css={css`
+        font-size: 13px;
+        font-style: normal;
+        font-weight: 400;
+        line-height: 19px;
+        text-align: left;
+      `}
+    >
+      {comment.text}
+    </div>
+  </div>
+);

--- a/frontend/src/components/qna/QnaCommentList.tsx
+++ b/frontend/src/components/qna/QnaCommentList.tsx
@@ -1,0 +1,31 @@
+/** @jsx jsx */
+import { css, jsx } from "@emotion/core";
+import React from "react";
+import { Comment } from "../../modules/qna";
+import { Divider } from "../common/Divider";
+import { QnaCommentItem } from "./QnaCommentItem";
+
+export interface QnaCommentListProps {
+  comments: Comment[];
+}
+
+export const QnaCommentList: React.FC<QnaCommentListProps> = ({
+  comments,
+  ...props
+}) => (
+  <div
+    css={css`
+      display: flex;
+      flex-direction: column;
+    `}
+    {...props}
+  >
+    <Divider />
+    {comments.map((comment) => (
+      <React.Fragment key={comment.id}>
+        <QnaCommentItem comment={comment} />
+        <Divider />
+      </React.Fragment>
+    ))}
+  </div>
+);

--- a/frontend/src/components/qna/QnaListWidget.tsx
+++ b/frontend/src/components/qna/QnaListWidget.tsx
@@ -1,0 +1,78 @@
+/** @jsx jsx */
+import { css, jsx } from "@emotion/core";
+import { useCallback } from "react";
+import { Link } from "react-router-dom";
+
+export interface QnaListWidgetProps {
+  title: string;
+  posts: { title: string; id: number }[];
+  onClick: (postId: number) => void;
+}
+
+export const QnaListWidget: React.FC<QnaListWidgetProps> = ({
+  title,
+  posts,
+  onClick,
+  ...props
+}) => {
+  const handleClick = useCallback(
+    (id: number) => {
+      onClick(id);
+    },
+    [onClick],
+  );
+  return (
+    <div {...props}>
+      <div
+        css={css`
+          font-style: normal;
+          font-weight: normal;
+          font-size: 14px;
+          line-height: 20px;
+          letter-spacing: -0.02em;
+
+          color: #323232;
+        `}
+      >
+        {title}
+      </div>
+      <div
+        css={css`
+          padding-top: 11px;
+          display: flex;
+          flex-direction: column;
+          a {
+            font-size: 12px;
+            font-style: normal;
+            font-weight: 400;
+            line-height: 17px;
+            letter-spacing: -0.02em;
+            text-align: left;
+            text-overflow: ellipsis;
+            word-break: break-word;
+            overflow-wrap: break-word;
+            display: -webkit-box;
+            -webkit-line-clamp: 1;
+            -webkit-box-orient: vertical;
+            overflow: hidden;
+            color: #627bff;
+            text-decoration: none;
+          }
+          a:not(:last-child) {
+            margin-bottom: 4px;
+          }
+        `}
+      >
+        {posts.map((post) => (
+          <Link
+            to={`/qna/${post.id}`}
+            key={post.id}
+            onClick={() => handleClick(post.id)}
+          >
+            {post.title}
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/qna/QnaPostItem.tsx
+++ b/frontend/src/components/qna/QnaPostItem.tsx
@@ -5,6 +5,7 @@ import { HTMLProps } from "react";
 import { QnaPost } from "../../modules/qna";
 import { AvatarIcon } from "../common/AvatarIcon";
 import { Divider } from "../common/Divider";
+import { QnaTagList } from "./QnaTagList";
 
 export interface QnaPostItemProps {
   post: QnaPost;
@@ -80,30 +81,15 @@ export const QnaPostItem: React.FC<
               height: 40px;
             `}
           >
-            {post.body}
+            {post.text}
           </div>
-          <div
+          <QnaTagList
             css={css`
-              display: flex;
               padding-top: 16px;
-
-              div {
-                background: #e6e6e6;
-                border-radius: 4px;
-                font-style: normal;
-                font-weight: normal;
-                font-size: 12px;
-                line-height: 17px;
-                letter-spacing: -0.02em;
-                padding: 2px 6px;
-              }
-              div:not(:last-child) {
-                margin-right: 6px;
-              }
             `}
           >
             <div>{post.tag}</div>
-          </div>
+          </QnaTagList>
         </QnaPostContent>
       </QnaPostWrapper>
       <Divider />

--- a/frontend/src/components/qna/QnaTagList.tsx
+++ b/frontend/src/components/qna/QnaTagList.tsx
@@ -1,0 +1,26 @@
+/** @jsx jsx */
+import { css, jsx } from "@emotion/core";
+
+export const QnaTagList: React.FC = ({ children, ...props }) => (
+  <div
+    css={css`
+      display: flex;
+      div {
+        background: #e6e6e6;
+        border-radius: 4px;
+        font-style: normal;
+        font-weight: normal;
+        font-size: 12px;
+        line-height: 17px;
+        letter-spacing: -0.02em;
+        padding: 2px 6px;
+      }
+      div:not(:last-child) {
+        margin-right: 6px;
+      }
+    `}
+    {...props}
+  >
+    {children}
+  </div>
+);

--- a/frontend/src/components/qna/Vote.tsx
+++ b/frontend/src/components/qna/Vote.tsx
@@ -1,11 +1,5 @@
 /** @jsx jsx */
 import { css, jsx } from "@emotion/core";
-import styled from "@emotion/styled";
-
-const SvgBlock = styled.div`
-  width: 20px;
-  height: 20px;
-`;
 
 const UpVote = () => (
   <svg

--- a/frontend/src/components/qna/Vote.tsx
+++ b/frontend/src/components/qna/Vote.tsx
@@ -1,0 +1,65 @@
+/** @jsx jsx */
+import { css, jsx } from "@emotion/core";
+import styled from "@emotion/styled";
+
+const SvgBlock = styled.div`
+  width: 20px;
+  height: 20px;
+`;
+
+const UpVote = () => (
+  <svg
+    width="20"
+    height="20"
+    viewBox="0 0 18 15"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path d="M9 0l8.66 15H.34L9 0z" fill="#C4C4C4" />
+  </svg>
+);
+const DownVote = () => (
+  <svg
+    width="20"
+    height="20"
+    viewBox="0 0 18 15"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path d="M9 15L.34 0h17.32L9 15z" fill="#C4C4C4" />
+  </svg>
+);
+
+export interface VoteProps {
+  votes: number;
+}
+
+export const Vote: React.FC<VoteProps> = ({ votes }) => (
+  <div
+    css={css`
+      display: flex;
+      flex-direction: column;
+      width: 20px;
+    `}
+  >
+    <UpVote />
+    <div
+      css={css`
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        margin-top: 8px;
+        margin-bottom: 8px;
+
+        font-size: 18px;
+        font-style: normal;
+        font-weight: 400;
+        line-height: 26px;
+        text-align: center;
+      `}
+    >
+      {votes}
+    </div>
+    <DownVote />
+  </div>
+);

--- a/frontend/src/containers/qna/QnaComments.tsx
+++ b/frontend/src/containers/qna/QnaComments.tsx
@@ -1,0 +1,57 @@
+/** @jsx jsx */
+import { css, jsx } from "@emotion/core";
+import { TextButton } from "../../components/common/TextButton";
+import { QnaCommentList } from "../../components/qna/QnaCommentList";
+import { Comment } from "../../modules/qna";
+
+const generateComments = (num: number): Comment[] =>
+  new Array(num).fill(null).map((_, idx) => {
+    return {
+      id: idx + 1,
+      user: {
+        id: idx + 1,
+        username: "홍길동",
+      },
+      text:
+        "보이는 이성은 노년에게서 동력은 것이다. 열락의 꽃 구할 못할 것이다.",
+      created_at: new Date().toString(),
+      isAuthor: (idx + 1) % 2 === 0,
+    };
+  });
+
+export const QnaComments: React.FC = () => {
+  const comments = generateComments(5);
+  return (
+    <div>
+      <QnaCommentList
+        comments={comments}
+        css={css`
+          padding-bottom: 7px;
+        `}
+      />
+      <div
+        css={css`
+          display: flex;
+          width: 100%;
+          justify-content: flex-end;
+        `}
+      >
+        <TextButton
+          css={css`
+            font-size: 12px;
+            font-style: normal;
+            font-weight: 400;
+            line-height: 17px;
+            letter-spacing: -0.02em;
+            text-align: right;
+            padding: 0;
+
+            color: #747474;
+          `}
+        >
+          새로운 댓글 달기
+        </TextButton>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/containers/qna/QnaHomeContainer.tsx
+++ b/frontend/src/containers/qna/QnaHomeContainer.tsx
@@ -3,15 +3,17 @@ import { css, jsx } from "@emotion/core";
 import { Button } from "../../components/common/Button";
 import { Sticky } from "../../components/common/Sticky";
 import { QnaSideBar } from "../../components/qna/QnaSideBar";
-import { RecentPosts } from "./RecentPosts";
+import { QnaRecentPosts } from "./QnaRecentPosts";
 
 export const QnaHomeContainer: React.FC = (props) => {
   return (
     <div
       css={css`
         max-width: 1100px;
+        margin: 0 auto;
         padding-left: 24px;
         padding-right: 24px;
+        padding-top: 83px;
       `}
       {...props}
     >
@@ -98,7 +100,7 @@ export const QnaHomeContainer: React.FC = (props) => {
             `}
             placeholder="질문 검색"
           />
-          <RecentPosts
+          <QnaRecentPosts
             css={css`
               padding-top: 38px;
             `}

--- a/frontend/src/containers/qna/QnaHomeContainer.tsx
+++ b/frontend/src/containers/qna/QnaHomeContainer.tsx
@@ -1,6 +1,7 @@
 /** @jsx jsx */
 import { css, jsx } from "@emotion/core";
 import { Button } from "../../components/common/Button";
+import { Sticky } from "../../components/common/Sticky";
 import { QnaSideBar } from "../../components/qna/QnaSideBar";
 import { RecentPosts } from "./RecentPosts";
 
@@ -63,11 +64,15 @@ export const QnaHomeContainer: React.FC = (props) => {
           padding-top: 120px;
         `}
       >
-        <QnaSideBar
+        <div
           css={css`
             width: 200px;
           `}
-        />
+        >
+          <Sticky top={120}>
+            <QnaSideBar />
+          </Sticky>
+        </div>
         <div
           css={css`
             padding-left: 16px;

--- a/frontend/src/containers/qna/QnaPostContainer.tsx
+++ b/frontend/src/containers/qna/QnaPostContainer.tsx
@@ -1,0 +1,99 @@
+/** @jsx jsx */
+import { css, jsx } from "@emotion/core";
+import { useCallback } from "react";
+import { useHistory } from "react-router-dom";
+import { OutlineButton } from "../../components/common/OutlineButton";
+import { QnaListWidget } from "../../components/qna/QnaListWidget";
+import { QnaPostViewer } from "./QnaPostViewer";
+
+export const QnaPostContainer: React.FC = () => {
+  const history = useHistory();
+  const onClick = useCallback(
+    (postId: number) => {
+      history.push(`/qna/post/${postId}`);
+    },
+    [history],
+  );
+  return (
+    <div
+      css={css`
+        max-width: 1100px;
+        margin: 0 auto;
+        padding-left: 24px;
+        padding-right: 24px;
+        padding-top: 83px;
+        display: flex;
+      `}
+    >
+      <QnaPostViewer
+        css={css`
+          flex: 1 1 auto;
+        `}
+      />
+      <div
+        css={css`
+          flex: 1 0 190px;
+          margin-top: 16px;
+          margin-left: 40px;
+          & > div:not(:last-child) {
+            padding-bottom: 28px;
+          }
+        `}
+      >
+        <OutlineButton
+          css={css`
+            margin-bottom: 34px;
+            width: 100%;
+            height: 28px;
+            border-radius: 6px;
+          `}
+        >
+          <div
+            css={css`
+              font-size: 12px;
+              font-style: normal;
+              font-weight: 400;
+              line-height: 17px;
+              letter-spacing: -0.02em;
+              text-align: center;
+            `}
+          >
+            새로운 질문하기
+          </div>
+        </OutlineButton>
+        <QnaListWidget
+          onClick={onClick}
+          title="답변을 기다리는 질문"
+          posts={[
+            { title: "빅 오(Big O) 계산은 어떻게 하나요?", id: 1 },
+            { title: "숫자 맞추기 게임 관련 질문", id: 2 },
+            { title: "자바 writeUTF 인코딩", id: 3 },
+            { title: "파이썬 질문 급해요 ㅜㅜ", id: 4 },
+            { title: "예외가 throw됨: 읽기 액세스 위반...", id: 5 },
+            {
+              title:
+                "빅 오 숫자 질문 throw됨: 계산은 인코딩 위반 관련 하나요? 숫자 급해요 예외가 ㅜㅜ",
+              id: 6,
+            },
+          ]}
+        />
+        <QnaListWidget
+          onClick={onClick}
+          title="최근 인기 질문"
+          posts={[
+            { title: "빅 오(Big O) 계산은 어떻게 하나요?", id: 1 },
+            { title: "숫자 맞추기 게임 관련 질문", id: 2 },
+            { title: "자바 writeUTF 인코딩", id: 3 },
+            { title: "파이썬 질문 급해요 ㅜㅜ", id: 4 },
+            { title: "예외가 throw됨: 읽기 액세스 위반...", id: 5 },
+            {
+              title:
+                "빅 오 숫자 질문 throw됨: 계산은 인코딩 위반 관련 하나요? 숫자 급해요 예외가 ㅜㅜ",
+              id: 6,
+            },
+          ]}
+        />
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/containers/qna/QnaPostViewer.tsx
+++ b/frontend/src/containers/qna/QnaPostViewer.tsx
@@ -1,0 +1,125 @@
+/** @jsx jsx */
+import { css, jsx } from "@emotion/core";
+import { AvatarIcon } from "../../components/common/AvatarIcon";
+import { VerticalDivider } from "../../components/common/VerticalDivider";
+import { QnaTagList } from "../../components/qna/QnaTagList";
+import { Vote } from "../../components/qna/Vote";
+import { QnaComments } from "./QnaComments";
+
+export const QnaPostViewer: React.FC = (props) => {
+  return (
+    <div
+      css={css`
+        display: flex;
+      `}
+      {...props}
+    >
+      <div
+        css={css`
+          width: 20px;
+          margin-top: 16px;
+        `}
+      >
+        <Vote votes={32} />
+      </div>
+      <div
+        css={css`
+          flex: 1 1 auto;
+          display: flex;
+          flex-direction: column;
+          margin-left: 32px;
+        `}
+      >
+        <div
+          css={css`
+            font-size: 30px;
+            font-style: normal;
+            font-weight: 400;
+            line-height: 43px;
+            letter-spacing: -0.02em;
+            text-align: left;
+            padding-bottom: 9px;
+
+            color: #323232;
+          `}
+        >
+          안드로이드 스튜디오 블루투스 질문
+        </div>
+        <div
+          css={css`
+            display: flex;
+            font-size: 12px;
+            font-style: normal;
+            font-weight: 400;
+            line-height: 17px;
+            letter-spacing: -0.02em;
+            text-align: left;
+            align-items: center;
+
+            & > *:not(:last-child) {
+              margin-right: 10px;
+            }
+            & > div {
+              color: #5a5a5a;
+            }
+          `}
+        >
+          <div
+            css={css`
+              display: flex;
+              color: #3e3e3e;
+              font-weight: 600;
+            `}
+          >
+            <AvatarIcon width={16} height={16} alt="@seowook12" />
+            <div>서욱</div>
+          </div>
+          <VerticalDivider
+            height={8}
+            css={css`
+              align-self: center;
+              fill: #c4c4c4;
+            `}
+          />
+          <div>2020.10.04 21:57</div>
+          <VerticalDivider
+            height={8}
+            css={css`
+              align-self: center;
+              fill: #c4c4c4;
+            `}
+          />
+          <div>조회수: 11,101</div>
+        </div>
+        <div
+          css={css`
+            padding-top: 40px;
+            padding-bottom: 40px;
+            font-size: 14px;
+            font-style: normal;
+            font-weight: 400;
+            line-height: 20px;
+            letter-spacing: 0em;
+            text-align: left;
+          `}
+        >
+          같으며, 보이는 이성은 노년에게서 동력은 것이다. 그들의 위하여 공자는
+          눈에 열매를 가진 청춘이 속에 천고에 부패뿐이다. 우리 수 창공에 듣기만
+          별과 천하를 피어나기 말이다. 설레는 크고 청춘을 옷을 커다란 듣기만
+          눈이 그들의 천하를 운다. 끝에 찾아 인간의 있는 청춘의 싹이 이상의
+          청춘의 이것이다. 인생에 없는 예가 피부가 천하를 원대하고, 가진 사랑의
+          보는 이것이다. 할지니, 너의 우리의 희망의 많이 것이다.
+        </div>
+        <QnaTagList
+          css={css`
+            padding-bottom: 26px;
+          `}
+        >
+          <div>안드로이드</div>
+          <div>Kotlin</div>
+        </QnaTagList>
+        <QnaComments />
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/containers/qna/QnaRecentPosts.tsx
+++ b/frontend/src/containers/qna/QnaRecentPosts.tsx
@@ -4,7 +4,7 @@ import { QnaPostItem } from "../../components/qna/QnaPostItem";
 import { QnaPostList } from "../../components/qna/QnaPostList";
 import useRecentPosts from "./hooks/useRecentPosts";
 
-export const RecentPosts: React.FC = (props) => {
+export const QnaRecentPosts: React.FC = (props) => {
   const { data, loading } = useRecentPosts();
 
   return (

--- a/frontend/src/containers/qna/hooks/useRecentPosts.ts
+++ b/frontend/src/containers/qna/hooks/useRecentPosts.ts
@@ -43,7 +43,7 @@ export default function useRecentPosts() {
     });
     setPage((page) => page + 1);
     setLoading(false);
-  }, [loading, setLoading, page, setPage, setData]);
+  }, [loading, setLoading, page, setPage, setData, data]);
 
   /* eslint-disable react-hooks/exhaustive-deps */
   // 첫 페이지는 스크롤 이벤트 없이 onLoadMore 함수 호출

--- a/frontend/src/modules/qna.ts
+++ b/frontend/src/modules/qna.ts
@@ -2,10 +2,21 @@ export interface QnaPost {
   id: number;
   user_id: string;
   title: string;
-  body: string;
+  text: string;
   tag: string;
   view: number;
   recommend: number;
-  created_at: Date;
-  updated_at: Date;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface Comment {
+  id: number;
+  user: {
+    id: number;
+    username: string;
+  };
+  text: string;
+  created_at: string;
+  isAuthor: boolean;
 }

--- a/frontend/src/stories/qna/QnaCommentItem.stories.tsx
+++ b/frontend/src/stories/qna/QnaCommentItem.stories.tsx
@@ -1,0 +1,32 @@
+/** @jsx jsx */
+import { jsx } from "@emotion/core";
+// also exported from '@storybook/react' if you can deal with breaking changes in 6.1
+import { Story, Meta } from "@storybook/react/types-6-0";
+
+import {
+  QnaCommentItem,
+  QnaCommentItemProps,
+} from "../../components/qna/QnaCommentItem";
+
+export default {
+  title: "qna/QnaCommentItem",
+  component: QnaCommentItem,
+} as Meta;
+
+const Template: Story<QnaCommentItemProps> = (args) => (
+  <QnaCommentItem {...args} />
+);
+
+export const Default = Template.bind({});
+Default.args = {
+  comment: {
+    id: 1,
+    user: {
+      id: 1,
+      username: "홍길동",
+    },
+    text: "보이는 이성은 노년에게서 동력은 것이다. 열락의 꽃 구할 못할 것이다.",
+    created_at: new Date().toString(),
+    isAuthor: true,
+  },
+};

--- a/frontend/src/stories/qna/QnaCommentList.stories.tsx
+++ b/frontend/src/stories/qna/QnaCommentList.stories.tsx
@@ -1,0 +1,37 @@
+/** @jsx jsx */
+import { jsx } from "@emotion/core";
+// also exported from '@storybook/react' if you can deal with breaking changes in 6.1
+import { Story, Meta } from "@storybook/react/types-6-0";
+import { QnaCommentItem } from "../../components/qna/QnaCommentItem";
+
+import {
+  QnaCommentList,
+  QnaCommentListProps,
+} from "../../components/qna/QnaCommentList";
+import { Comment } from "../../modules/qna";
+
+export default {
+  title: "qna/QnaCommentList",
+  component: QnaCommentList,
+} as Meta;
+
+const generateComments = (num: number): Comment[] =>
+  new Array(num).fill(null).map((_, idx) => {
+    return {
+      id: idx + 1,
+      user: {
+        id: idx + 1,
+        username: "홍길동",
+      },
+      text:
+        "보이는 이성은 노년에게서 동력은 것이다. 열락의 꽃 구할 못할 것이다.",
+      created_at: new Date().toString(),
+      isAuthor: (idx + 1) % 2 === 0,
+    };
+  });
+
+const Template: Story<QnaCommentListProps> = (args) => {
+  return <QnaCommentList {...args} comments={generateComments(5)} />;
+};
+export const Default = Template.bind({});
+Default.args = {};

--- a/frontend/src/stories/qna/QnaListWidget.stories.tsx
+++ b/frontend/src/stories/qna/QnaListWidget.stories.tsx
@@ -1,0 +1,50 @@
+/** @jsx jsx */
+import { jsx } from "@emotion/core";
+// also exported from '@storybook/react' if you can deal with breaking changes in 6.1
+import { Story, Meta } from "@storybook/react/types-6-0";
+import { MemoryRouter } from "react-router-dom";
+
+import {
+  QnaListWidget,
+  QnaListWidgetProps,
+} from "../../components/qna/QnaListWidget";
+
+export default {
+  title: "qna/QnaListWidget",
+  component: QnaListWidget,
+} as Meta;
+
+const Template: Story<QnaListWidgetProps> = (args) => (
+  <MemoryRouter>
+    <QnaListWidget {...args} />
+  </MemoryRouter>
+);
+
+export const Recent = Template.bind({});
+Recent.args = {
+  title: "답변을 기다리는 질문",
+  posts: [
+    { title: "빅 오(Big O) 계산은 어떻게 하나요?", id: 1 },
+    { title: "숫자 맞추기 게임 관련 질문", id: 2 },
+    { title: "자바 writeUTF 인코딩", id: 3 },
+    { title: "파이썬 질문 급해요 ㅜㅜ", id: 4 },
+    { title: "예외가 throw됨: 읽기 액세스 위반...", id: 5 },
+    {
+      title:
+        "빅 오 숫자 질문 throw됨: 계산은 인코딩 위반 관련 하나요? 숫자 급해요 예외가 ㅜㅜ",
+      id: 6,
+    },
+  ],
+};
+
+export const Trending = Template.bind({});
+Trending.args = {
+  title: "최근 인기 질문",
+  posts: [
+    { title: "빅 오(Big O) 계산은 어떻게 하나요?", id: 1 },
+    { title: "숫자 맞추기 게임 관련 질문", id: 2 },
+    { title: "자바 writeUTF 인코딩", id: 3 },
+    { title: "파이썬 질문 급해요 ㅜㅜ", id: 4 },
+    { title: "예외가 throw됨: 읽기 액세스 위반...", id: 5 },
+  ],
+};

--- a/frontend/src/stories/qna/QnaPostItem.stories.tsx
+++ b/frontend/src/stories/qna/QnaPostItem.stories.tsx
@@ -21,12 +21,12 @@ Default.args = {
     id: 1,
     user_id: "seowook1963",
     title: "안드로이드 블루투스 연결 질문",
-    body:
+    text:
       "앞이 날카로우나 방황하였으며, 남는 황금시대의 커다란 그리하였는가?\n피에 불어 용감하고 말이다. 청춘에서만 듣기만 앞이 많이 부패뿐이다. 노년에게서 커다란 것이다.보라, 군영과 영락과 하여도...앞이 날카로우나 방황하였으며, 남는 황금시대의 커다란 그리하였는가? 피에 불어 용감하고 말이다. 청춘에서만 듣기만 앞이 많이 부패뿐이다. 노년에게서 커다란 것이다.보라, 군영과 영락과 하여도...",
     tag: "안드로이드",
     view: 321,
     recommend: 14,
-    created_at: new Date(),
-    updated_at: new Date(),
+    created_at: new Date().toString(),
+    updated_at: new Date().toString(),
   },
 };

--- a/frontend/src/stories/qna/QnaPostList.stories.tsx
+++ b/frontend/src/stories/qna/QnaPostList.stories.tsx
@@ -30,13 +30,13 @@ const generatePosts = (num: number): QnaPost[] =>
     id: idx + 1,
     user_id: "seowook1963",
     title: "안드로이드 블루투스 연결 질문",
-    body:
+    text:
       "앞이 날카로우나 방황하였으며, 남는 황금시대의 커다란 그리하였는가?\n피에 불어 용감하고 말이다. 청춘에서만 듣기만 앞이 많이 부패뿐이다. 노년에게서 커다란 것이다.보라, 군영과 영락과 하여도...앞이 날카로우나 방황하였으며, 남는 황금시대의 커다란 그리하였는가? 피에 불어 용감하고 말이다. 청춘에서만 듣기만 앞이 많이 부패뿐이다. 노년에게서 커다란 것이다.보라, 군영과 영락과 하여도...",
     tag: "안드로이드",
     view: 321,
     recommend: 14,
-    created_at: new Date(),
-    updated_at: new Date(),
+    created_at: new Date().toString(),
+    updated_at: new Date().toString(),
   }));
 
 export const Default = Template.bind({});

--- a/frontend/src/stories/qna/Vote.stories.tsx
+++ b/frontend/src/stories/qna/Vote.stories.tsx
@@ -1,0 +1,22 @@
+/** @jsx jsx */
+import { jsx } from "@emotion/core";
+// also exported from '@storybook/react' if you can deal with breaking changes in 6.1
+import { Story, Meta } from "@storybook/react/types-6-0";
+
+import { Vote, VoteProps } from "../../components/qna/Vote";
+
+export default {
+  title: "qna/Vote",
+  component: Vote,
+} as Meta;
+
+const Template: Story<VoteProps> = (args) => (
+  <div>
+    <Vote {...args} />
+  </div>
+);
+
+export const Default = Template.bind({});
+Default.args = {
+  votes: 5,
+};


### PR DESCRIPTION
![146](https://user-images.githubusercontent.com/17797795/96273037-d89f4a00-1009-11eb-874b-78bcbdcad1c5.png)

#7 

### 주요 변경사항
 - QnA 글 페이지 질문 글 까지 구현

### 기타 변경사항
 - mock 서버에 QnA 글 목록 테스트용 `/board/:id` API 추가 (https://github.com/osamhack2020/WEB_CodeSquare_AmongUs/commit/aec86f34ec88ce24f3c4be97e14243694e9c2882)
 - Header에 QnA 링크 추가 / vm 링크가 `/vm`이 아닌 `vm`으로 되어 상대 경로로 취급되던 점 수정 (https://github.com/osamhack2020/WEB_CodeSquare_AmongUs/commit/03032354005000178f9aca47484570c1f3ed05ac)
 - OutlineButton, VerticalDivider 컴포넌트 추가 (https://github.com/osamhack2020/WEB_CodeSquare_AmongUs/commit/8c8a7e913b31bb7b4d0b30e63b1d383aa8a5e8db)
 - QnaSideBar 컴포넌트에 sticky 효과 추가 (https://github.com/osamhack2020/WEB_CodeSquare_AmongUs/commit/d3e8646a4e5a99e7cb3f7dc95716f8acb77f86b9)
